### PR TITLE
Modifications for Fitbug technical testing

### DIFF
--- a/Test-Automation.md
+++ b/Test-Automation.md
@@ -30,6 +30,8 @@ Feature: Use the app to compete in a challenge
       When I view my Team in the Leaderboard 
       Then I will see a combined 'Average team steps' count	  
 ```
+
+The 'game' name that should be used within API requests is 'fitbugdemo'
  
 1. Implement your suite of tests to run in an automated fashion
 

--- a/Test-Automation.md
+++ b/Test-Automation.md
@@ -1,6 +1,6 @@
-# [Company Name] Test Automation Test
+# Fitbug Test Automation Test
 
-Thank you for applying for a role at [Company Name], the following assessment consists of three parts:
+Thank you for applying for a role at Fitbug, the following assessment consists of three parts:
 
 * [A technical exercise](#technical-exercise) 
 * [Technical questions](#technical-questions)

--- a/Test-Automation.md
+++ b/Test-Automation.md
@@ -8,20 +8,27 @@ Thank you for applying for a role at Fitbug, the following assessment consists o
 
 ## Technical Exercise
 
-The following website [http://test.my.kiqplan.com/fitbugdemo/game/fitbug-step-challenge/app](Kiqplan app) demonstrates the Fitbug step challenge. The application builds on top of the [Kiqplan API](http://test.kiqplan.com/documentation/v2/). 
+The following website [Kiqplan app](http://test.my.kiqplan.com/fitbugdemo/game/fitbug-step-challenge/app) demonstrates the Fitbug step challenge. The application builds on top of the [Kiqplan API](http://test.kiqplan.com/api/v2/) which is [documented here](http://test.kiqplan.com/documentation/v2/). 
 
-1. Write a suite of functional tests in Cucumber syntax to cover some functionality of the site above, you must include the following scenario.
+You will be provided a login for the 'Kiqplan app' that will also allow you to authenticate with the API. 
+
+1. Write a suite of functional tests in Cucumber syntax to cover some functionality of the site above, you must include the following two scenarios.
 
 ```
-Feature: Use the website to find out about a person 
-   So that I can decide whether to interview a person
-   As a recruiter
-   I want to know about them
+Feature: Use the app to compete in a challenge
+   So that I can compete in a step challenge
+   As a company employee
+   I want to be part of a Team
 
    Scenario:
-      Given I want to know about the person 
-      When I select 'About' in the menu 
-      Then I will see information about the person
+      Given I am a Team member
+      When I select my Team in the Leaderboard 
+      Then I will see my 'Total steps'
+	  
+   Scenario:
+      Given I am a Team member
+      When I view my Team in the Leaderboard 
+      Then I will see a combined 'Average team steps' count	  
 ```
  
 1. Implement your suite of tests to run in an automated fashion
@@ -48,6 +55,6 @@ Please provide all technical questions in a markdown file
 1. What areas particularly interest you in the world of test automation?
 
 ## Submitting Answers
-Please submit the full assessment as one zip file, this should be named **{firstname-secondname-role-applied-for}.zip** and should be emailed to whoever@whoever.com
+Please submit the full assessment as one zip file, this should be named **{firstname-secondname-role-applied-for}.zip** and should be emailed to whoever@fitbug.com
 
 

--- a/Test-Automation.md
+++ b/Test-Automation.md
@@ -55,6 +55,6 @@ Please provide all technical questions in a markdown file
 1. What areas particularly interest you in the world of test automation?
 
 ## Submitting Answers
-Please submit the full assessment as one zip file, this should be named **{firstname-secondname-role-applied-for}.zip** and should be emailed to whoever@fitbug.com
+Please submit the full assessment as one zip file, this should be named **{firstname-secondname-role-applied-for}.zip** and should be added to the shared DropBox folder you are provided when requested to complete the test.
 
 

--- a/Test-Automation.md
+++ b/Test-Automation.md
@@ -41,13 +41,10 @@ Feel free to spend as much or as little time as you like (although a guideline w
 * Provide instructions on how to run your tests for the technical exercise, clarity and accuracy of these instructions is important, please create a README file containing the instructions
 
 ### Choice of tools
-
-You can solve the technical test using any tools of choice, we use tools such as:
-* Visual Studio 
-* SpecFlow
-* Coded UI
-* Selenium WebDriver
-* Protractor
+You can solve the technical test using your tools of choice, our technology stack looks something like this:
+* AWS
+* LAMP
+* React
 
 ## Technical Questions
 Please provide all technical questions in a markdown file

--- a/Test-Automation.md
+++ b/Test-Automation.md
@@ -8,7 +8,7 @@ Thank you for applying for a role at Fitbug, the following assessment consists o
 
 ## Technical Exercise
 
-The following website [https://github.com/lholman/portfolio-redux-app](portfolio app) provides a simple online portfolio website based on a particular users public github account. It utilises REACT and the github API. 
+The following website [http://test.my.kiqplan.com/fitbugdemo/game/fitbug-step-challenge/app](Kiqplan app) demonstrates the Fitbug step challenge. The application builds on top of the [Kiqplan API](http://test.kiqplan.com/documentation/v2/). 
 
 1. Write a suite of functional tests in Cucumber syntax to cover some functionality of the site above, you must include the following scenario.
 


### PR DESCRIPTION
This PR includes the changes to the original generic technical test to make it more specific to recruitment of a Fitbug QA Engineer. I would recommend the following steps are completed prior to providing candidates with the test
- [ ] Create a test user for each candidate (using their email address) who is a member of a team (with other test members) that is competing in the 'fitbugdemo' game
- [ ] Provide the candidate with their user login details
- [ ] Invite each candidate to submit their assessment via a DropBox shared folder named firstname-lastname
- [ ] Familiarise yourselves with the test, in particular what success will look like